### PR TITLE
Fix IB accountsList recognition error, such as 'account1,account2,'

### DIFF
--- a/vnpy_ib/ib_gateway.py
+++ b/vnpy_ib/ib_gateway.py
@@ -601,7 +601,8 @@ class IbApi(EWrapper):
 
         if not self.account:
             for account_code in accountsList.split(","):
-                self.account = account_code
+                if account_code:
+                    self.account = account_code
 
         self.gateway.write_log(f"当前使用的交易账号为{self.account}")
         self.client.reqAccountUpdates(True, self.account)


### PR DESCRIPTION
IB 顾问账号会产生'account1,account2,'这种类型的accountsList