### PR TITLE
增加COMEX交易所支持,修复Conid填写错误导致的API断开连接

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .vscode/settings.json
+.idea

--- a/vnpy_ib/ib_gateway.py
+++ b/vnpy_ib/ib_gateway.py
@@ -111,7 +111,8 @@ EXCHANGE_VT2IB: Dict[Exchange, str] = {
     Exchange.OTC: "PINK",
     Exchange.SGX: "SGX",
     Exchange.CBOE: "CBOE",
-    Exchange.CBOT: "CBOT"
+    Exchange.CBOT: "CBOT",
+    Exchange.COMEX: "COMEX"
 }
 EXCHANGE_IB2VT: Dict[str, Exchange] = {v: k for k, v in EXCHANGE_VT2IB.items()}
 
@@ -876,7 +877,11 @@ class IbApi(EWrapper):
         self.subscribed[req.vt_symbol] = req
 
         # 解析IB合约详情
-        ib_contract: Contract = generate_ib_contract(req.symbol, req.exchange)
+        try:
+            ib_contract: Contract = generate_ib_contract(req.symbol, req.exchange)
+        except Exception as e:
+            self.gateway.write_log(str(e))
+            return
         if not ib_contract:
             self.gateway.write_log("代码解析失败，请检查格式是否正确")
             return
@@ -1103,6 +1108,9 @@ def generate_ib_contract(symbol: str, exchange: Exchange) -> Optional[Contract]:
     else:
         ib_contract: Contract = Contract()
         ib_contract.exchange = EXCHANGE_VT2IB[exchange]
-        ib_contract.conId = symbol
+        if symbol.isdigit():
+            ib_contract.conId = symbol
+        else:
+            raise ValueError(f"Conid类型代码必须是纯数字, 请检查代码 `{symbol}` 是否正确！")
 
     return ib_contract


### PR DESCRIPTION
1. 增加COMEX交易所支持
2. 修复当用户输入的代码是Conid类型并且非纯数字导致的与TWS或者IbGateway之间的连接断开（不可恢复），必须重启vnpy的bug. 错误信息如下
```
IB TWS连接断开
信息通知，代码：320，内容: Error reading request: Unable to parse data. java.lang.NumberFormatException: For input string: "553616312  "
```
修复后的日志效果
![image](https://github.com/vnpy/vnpy_ib/assets/28781481/8152c423-41f0-4ee2-ad8a-ee17c18fa7e0)
